### PR TITLE
Fixed broken scaffolding and added ziggy with route auto-completion

### DIFF
--- a/preset.ts
+++ b/preset.ts
@@ -51,34 +51,42 @@ Preset.group((preset) => {
 	mixConfig
 		.update((content) => content.replace(/\.js/g, '.ts').replace('/js', '/scripts'))
 		.addAfter('mix.ts', [
-			'	.vue()',
-			'	.alias({',
-			'	  vue$: `${__dirname}/node_modules/vue/dist/vue.esm-bundler.js`,',
-			'	  ziggy: `${__dirname}/vendor/tightenco/ziggy/dist`,',
-			"	  '@': `${__dirname}/resources/views`,",
-			"	  '@scripts': `${__dirname}/resources/scripts`",
-			`	})`,
-			'	.webpackConfig(({ DefinePlugin }) => ({',
-			'			output: {',
-			'					chunkFilename: `js/chunks/[name].js?id=[chunkhash]`',
-			'			},',
-			'			plugins: [',
-			'					new DefinePlugin({',
-			"							__VUE_OPTIONS_API__: 'true',",
-			"							__VUE_PROD_DEVTOOLS__: 'false',",
-			'					}),',
-			'			],',
-			'	}))',
-			'	.version()',
-			'	.sourceMaps(false)',
-			'	.ziggy()',
-		]);
+			'.vue()',
+			'.alias({',
+			'  vue$: `${__dirname}/node_modules/vue/dist/vue.esm-bundler.js`,',
+			'  ziggy: `${__dirname}/vendor/tightenco/ziggy/dist`,',
+			"  '@': `${__dirname}/resources/views`,",
+			"  '@scripts': `${__dirname}/resources/scripts`",
+			`})`,
+			'.webpackConfig(({ DefinePlugin }) => ({',
+			'		output: {',
+			'				chunkFilename: `js/chunks/[name].js?id=[chunkhash]`',
+			'		},',
+			'		plugins: [',
+			'				new DefinePlugin({',
+			"						__VUE_OPTIONS_API__: 'true',",
+			"						__VUE_PROD_DEVTOOLS__: 'false',",
+			'				}),',
+			'		],',
+			'}))',
+			'.version()',
+			'.sourceMaps(false)',
+			'.ziggy()',
+		])
+		.withIndent(4);
 
 	// Updates routes
 	preset
 		.edit('routes/web.php')
 		.update((content) => content.replace('view', 'inertia').replace('welcome', 'Welcome'))
 		.withTitle('Updating routes...');
+
+	// Add the inertia middleware to the Laravel Kernel
+	preset
+		.edit('app/Http/Kernel.php')
+		.addBefore("'api' =>", '	\\App\\Http\\Middleware\\HandleInertiaRequests::class,')
+		.skipLines(2)
+		.withIndent(9);
 }).withTitle(`Updating the ${color.magenta('Mix')} and ${color.magenta('routes')}...`);
 
 // Adds dependencies

--- a/templates/default/resources/scripts/app.ts
+++ b/templates/default/resources/scripts/app.ts
@@ -1,6 +1,16 @@
+import '@scripts/bootstrap';
 import { createApp, h } from 'vue';
+import type { Inertia, Page } from '@inertiajs/inertia';
 import { app, plugin } from '@inertiajs/inertia-vue3';
 import { InertiaProgress } from '@inertiajs/progress';
+
+declare module '@vue/runtime-core' {
+	interface ComponentCustomProperties {
+		$route: typeof route;
+		$inertia: Inertia;
+		$page: Page<CustomPageProps<unknown>>;
+	}
+}
 
 InertiaProgress.init({
 	delay: 250,
@@ -15,8 +25,10 @@ createApp({
 	render: () =>
 		h(app, {
 			initialPage: JSON.parse(root.dataset.page!),
-			resolveComponent: (name: string) => require(`../views/pages/${name}`).default,
+			resolveComponent: (name: string) =>
+				import(`../views/pages/${name}`).then((module) => module.default),
 		}),
 })
+	.mixin({ methods: { $route: route } })
 	.use(plugin)
 	.mount(root);

--- a/templates/default/resources/scripts/bootstrap.js
+++ b/templates/default/resources/scripts/bootstrap.js
@@ -1,0 +1,4 @@
+import route from 'ziggy';
+import { Ziggy } from '@scripts/generated/ziggy';
+
+window.route = (name, params, absolute, config = Ziggy) => route(name, params, absolute, config);

--- a/templates/default/resources/scripts/types.d.ts
+++ b/templates/default/resources/scripts/types.d.ts
@@ -1,4 +1,8 @@
-// TODO: PR inertia
+declare module "*.vue" {
+    import { defineComponent } from "vue";
+    const _default: ReturnType<typeof defineComponent>;
+    export default _default;
+}
 
 type CustomPageProps<T> = T & { errors: { [key: string]: string } };
 

--- a/templates/default/resources/scripts/types.d.ts
+++ b/templates/default/resources/scripts/types.d.ts
@@ -1,7 +1,17 @@
 // TODO: PR inertia
+
+type CustomPageProps<T> = T & { errors: { [key: string]: string } };
+
 declare module '@inertiajs/inertia-vue3' {
+	import { ComputedRef } from 'vue';
+	import { Page } from '@inertiajs/inertia';
 	export const app: any;
 	export const plugin: {
 		install(vue: any): void;
 	};
+	export function usePage<T>(): Page<ComputedRef<CustomPageProps<T>>>;
 }
+
+type Routes = keyof typeof import('@scripts/generated/ziggy').Ziggy['routes'];
+declare const route: ((name: Routes, params?: any) => string) &
+	(() => { current: (name: Routes) => boolean } & { current: () => Routes });

--- a/templates/default/resources/views/app.blade.php
+++ b/templates/default/resources/views/app.blade.php
@@ -3,8 +3,8 @@
 		<head>
 				<meta charset="utf-8" />
 				<meta name="viewport" content="width=device-width, initial-scale=1" />
-				<link href="{{ mix('/build/app.css') }}" rel="stylesheet" />
-    		<script src="{{ mix('/build/app.js') }}" defer></script>
+				<link href="{{ mix('/css/app.css') }}" rel="stylesheet" />
+    			<script src="{{ mix('/js/app.js') }}" defer></script>
 		</head>
 		<body>
 			@inertia

--- a/templates/default/tsconfig.json
+++ b/templates/default/tsconfig.json
@@ -2,6 +2,8 @@
 	"compilerOptions": {
 		"target": "esnext",
 		"module": "esnext",
+		"allowJs": true,
+		"outDir": "./temp", // won't actually emit output, just for validity of the config. Required for "allowJs" (for Ziggy auto-complete)
 		"strict": true,
 		"importHelpers": true,
 		"moduleResolution": "node",


### PR DESCRIPTION
# Some Enhancements

**Hi ✌**
I really loved you Inertia preset, yet I had some issues with it on a fresh project.
So I decided to fix the broken scaffolding and add some new features.

**Ziggy** - which is basically almost mandatory for every Inertia application (most users use it)
It has auto-completion for the route names for easy navigation. (Auto-completion for route params is not possible)
![image](https://user-images.githubusercontent.com/12978732/100724005-134b1f00-33cb-11eb-8216-de9371c296e6.png)

**Code-splitting/Lazy-Loading** - very useful for every Inertia application.

**Types for usePage()** - usePage() is a Vue 3 hook (is it called hook?) that allows to get the current page when using the Composition API. Will no longer be needed when Inertia publish Vue 3 typings but as of now there aren't.

**Added HandleInertiaRequests to the Laravel Kernel** - That middleware is not auto-discovered by Laravel by any means, we need to load it to the Kernel.

Feel free to leave any feedback and of course make changes to the updated code.