### PR TITLE
Separate package.json devDependencies

### DIFF
--- a/preset.ts
+++ b/preset.ts
@@ -72,16 +72,24 @@ async function installBase() {
 	await installPackages({
 		for: 'node',
 		install: [
-			'vue@next',
 			'@vue/compiler-sfc',
 			'@vitejs/plugin-vue',
-			'@inertiajs/inertia',
-			'@inertiajs/inertia-vue3',
 			'laravel-vite',
 			'vite',
 		],
+		dev: true,
 		title: 'install front-end dependencies',
 	})
+	
+	await installPackages({
+		for: 'node',
+		install: [
+			'vue@next',
+			'@inertiajs/inertia',
+			'@inertiajs/inertia-vue3',
+		],
+		title: 'install front-end dependencies',
+	})	
 
 	await installPackages({
 		for: 'php',


### PR DESCRIPTION
I noticed that dependencies like `vue` and `vite` were all under `dependencies` in the `package.json`. Not sure if there's an intentional reason for this, but I think that things like `vite` should be under `devDependencies`.