### PR TITLE
Replace `replace()` method with `replaceAll()`

### DIFF
--- a/templates/default/resources/scripts/vite/import-page-component.ts
+++ b/templates/default/resources/scripts/vite/import-page-component.ts
@@ -1,7 +1,7 @@
 export function importPageComponent(name: string, pages: Record<string, any>) {
 	// eslint-disable-next-line no-restricted-syntax
 	for (const path in pages) {
-		if (path.endsWith(`${name.replace('.', '/')}.vue`)) {
+		if (path.endsWith(`${name.replaceAll('.', '/')}.vue`)) {
 			return typeof pages[path] === 'function'
 				? pages[path]()
 				: pages[path]


### PR DESCRIPTION
Using `replace()` instead of `replaceAll()` will only replace the first dot. What we need is to replace all dots with a slash instead.