### PR TITLE
Adjust vite-layout regex to allow accessing subdirectories

### DIFF
--- a/templates/default/resources/scripts/vite/inertia-layout.ts
+++ b/templates/default/resources/scripts/vite/inertia-layout.ts
@@ -1,7 +1,7 @@
-import { Plugin } from 'vite'
+import type { Plugin } from 'vite'
 
 const PLUGIN_NAME = 'vite:inertia:layout'
-const TEMPLATE_LAYOUT_REGEX = /<template +layout(?: *= *['"](?:(?:(\w+):)?(\w+))['"] *)?>/
+const TEMPLATE_LAYOUT_REGEX = /<template +layout(?: *= *['"]([\w\/]+)['"] *)?>/
 
 /**
  * A basic Vite plugin that adds a <template layout="name"> syntax to Vite SFCs.


### PR DESCRIPTION
This small patch adjusts the regex for the template utility plugin.
With these changes one can now also use layouts in subfolders like "Admin/Login.vue". Previously only single words were allowed and honestly i have no idea what the regex was supposed to catch, so i adjusted it to be more general.

Additionally mark the import as a type import only :)