### PR TITLE
refactor(inertia-layout): remove unnecessary escape from regex

### DIFF
--- a/templates/default/resources/scripts/vite/inertia-layout.ts
+++ b/templates/default/resources/scripts/vite/inertia-layout.ts
@@ -1,7 +1,7 @@
 import type { Plugin } from 'vite'
 
 const PLUGIN_NAME = 'vite:inertia:layout'
-const TEMPLATE_LAYOUT_REGEX = /<template +layout(?: *= *['"]([-_\w\/]+)['"] *)?>/
+const TEMPLATE_LAYOUT_REGEX = /<template +layout(?: *= *['"]([-_\w/]+)['"] *)?>/
 
 /**
  * A basic Vite plugin that adds a <template layout="name"> syntax to Vite SFCs.


### PR DESCRIPTION
This is to resolve eslint's `no-useless-escape` warning on the regex. It keeps same functionality